### PR TITLE
Switch one PI to M_PI to support STRICT_R_HEADERS in Rcpp

### DIFF
--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -86,7 +86,7 @@ arma::colvec dmatnorm_calc(arma::cube& x, arma::mat& mean, arma::mat& U,
   arma::colvec logresult(x.n_slices);
   for (int i = 0; i < numslices; i++) {
     arma::mat XM = x.slice(i) - mean;
-    logresult(i) = -0.5 * n * p * log(2 * PI) - 0.5 * p * logdetU -
+    logresult(i) = -0.5 * n * p * log(2 * M_PI) - 0.5 * p * logdetU -
                    0.5 * n * logdetV -
                    0.5 * trace(Vinv * trans(XM) * Uinv * XM);
   }


### PR DESCRIPTION
Dear Geoffrey,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history.

Your package uses (in one file) PI (instead of the standard C define M_PI) and PI goes away when we set STRICT_R_HEADERS (as a #define in a header or source file, a -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do). We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

This very simple PR changes PI to M_PI. Your code will then work with and without STRICT_R_HEADERS (as M_PI is an old define from C). PI only works when STRICT_R_HEADERS is not defined.  As an RcppArmadillo user you could also use arma::datum::pi but M_PI indeed pretty common.

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.